### PR TITLE
replace this to work with chatterbot 1.0.5

### DIFF
--- a/chatterbot_modified.py
+++ b/chatterbot_modified.py
@@ -1,7 +1,7 @@
 import logging
 from chatterbot.storage import StorageAdapter
 from chatterbot.logic import LogicAdapter
-from chatterbot.search import TextSearch, IndexedTextSearch
+from chatterbot.search import IndexedTextSearch
 from chatterbot import utils
 
 
@@ -28,11 +28,9 @@ class ChatBot(object):
         self.storage = utils.initialize_class(storage_adapter, **kwargs)
 
         primary_search_algorithm = IndexedTextSearch(self, **kwargs)
-        text_search_algorithm = TextSearch(self, **kwargs)
 
         self.search_algorithms = {
-            primary_search_algorithm.name: primary_search_algorithm,
-            text_search_algorithm.name: text_search_algorithm
+            primary_search_algorithm.name: primary_search_algorithm
         }
 
         for adapter in logic_adapters:
@@ -108,10 +106,10 @@ class ChatBot(object):
         # Make sure the input statement has its search text saved
 
         if not input_statement.search_text:
-            input_statement.search_text = self.storage.tagger.get_text_index_string(input_statement.text)
+            input_statement.search_text = self.storage.tagger.get_bigram_pair_string(input_statement.text)
 
         if not input_statement.search_in_response_to and input_statement.in_response_to:
-            input_statement.search_in_response_to = self.storage.tagger.get_text_index_string(input_statement.in_response_to)
+            input_statement.search_in_response_to = self.storage.tagger.get_bigram_pair_string(input_statement.in_response_to)
 
         response = self.generate_response(input_statement, additional_response_selection_parameters)
 


### PR DESCRIPTION
Also remove class `TextSearch` from `chatterbot.search` as it is not there in 1.0.5. Then it should work.
Code should match version from `requirements.txt`